### PR TITLE
Add Tkinter Pourbaix GUI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Electrochemetriste Pourbaix Diagram GUI
+
+This repository contains a simple Tkinter-based GUI for drawing Eh-pH (Pourbaix) diagrams using the `pyCHNOSZ` 0.9.1 library. The application lets you select compounds from a list and draw the diagram in the center of the window.
+
+## Usage
+
+1. Install the required dependencies:
+   ```bash
+   pip install pyCHNOSZ==0.9.1 matplotlib
+   ```
+2. Run the program:
+   ```bash
+   python pourbaix_gui.py
+   ```
+3. Select one or more compounds from the list on the left and click **Draw** to display the diagram.
+
+Note: The example species are placeholders. You can modify the default list or provide your own.

--- a/pourbaix_gui.py
+++ b/pourbaix_gui.py
@@ -1,0 +1,73 @@
+import sys
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+
+try:
+    import pyCHNOSZ as pyc
+except ImportError:
+    pyc = None
+
+
+def draw_pourbaix(selected_species):
+    if pyc is None:
+        messagebox.showerror("pyCHNOSZ not available", "pyCHNOSZ 0.9.1 must be installed")
+        return None
+    # Setup the aqueous basis species
+    try:
+        pyc.reset()
+        pyc.basis("CHNOS+", selected_species)
+        fig = plt.figure(figsize=(5,4))
+        pyc.diagram("Eh-pH", fig=fig)
+        return fig
+    except Exception as e:
+        messagebox.showerror("Diagram error", str(e))
+        return None
+
+
+def on_draw(fig_area, species_listbox):
+    selected = [species_listbox.get(i) for i in species_listbox.curselection()]
+    if not selected:
+        messagebox.showinfo("Selection required", "Please select at least one species")
+        return
+    fig = draw_pourbaix(selected)
+    if fig:
+        for widget in fig_area.winfo_children():
+            widget.destroy()
+        canvas = FigureCanvasTkAgg(fig, master=fig_area)
+        canvas.draw()
+        canvas.get_tk_widget().pack(fill="both", expand=True)
+
+
+def main(species):
+    root = tk.Tk()
+    root.title("pyCHNOSZ Pourbaix Diagram")
+
+    left_frame = ttk.Frame(root)
+    left_frame.pack(side="left", fill="y")
+
+    list_label = ttk.Label(left_frame, text="Compounds")
+    list_label.pack(padx=5, pady=5)
+
+    species_var = tk.StringVar(value=species)
+    species_listbox = tk.Listbox(left_frame, listvariable=species_var, selectmode="multiple", height=15)
+    species_listbox.pack(padx=5, pady=5)
+
+    draw_btn = ttk.Button(left_frame, text="Draw", command=lambda: on_draw(fig_area, species_listbox))
+    draw_btn.pack(padx=5, pady=5)
+
+    fig_area = ttk.Frame(root, borderwidth=2, relief="sunken")
+    fig_area.pack(side="right", fill="both", expand=True)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    default_species = [
+        "H2O", "O2", "H+", "H2", "CO2", "CO3--", "CH4"  # Example species
+    ]
+    main(default_species)


### PR DESCRIPTION
## Summary
- add Tkinter GUI that plots Pourbaix diagrams using pyCHNOSZ
- document how to install dependencies and run the GUI

## Testing
- `pytest -q`
- *(failure)* `pip install pyCHNOSZ==0.9.1`

------
https://chatgpt.com/codex/tasks/task_e_6870ee5b1d648322856c40d6c9a75222